### PR TITLE
Recognize `-nostdinc`, `-nostdinc++` & friends for Clang and GCC

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This library is inspired by tools such as [nickdiego/compiledb](https://github.c
    + [response file](https://gcc.gnu.org/wiki/Response_Files) expansion;
    + support for 'single'- and "double"-quoted arguments (also within response files);
    + include paths (`-I`, `-include`, `-isystem` and so on) recognized;
-   + defined (-D) and undefined (-U) preprocessor macros recognized;
+   + defined (`-D`) and undefined (`-U`) preprocessor macros recognized;
    + language (C, C++) and standard (`c++17`, `gnu++14`) recognized;
    + `-nostdinc`, `-nostdinc++` and similar switches recognized.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ This library is inspired by tools such as [nickdiego/compiledb](https://github.c
    Built-in path mapper for [_MSys_](https://www.msys2.org).
  - Command-line parser for _GCC_ and compatibles, such as _Clang_:
    + [response file](https://gcc.gnu.org/wiki/Response_Files) expansion;
-   + support for 'single'- and "double"-quoted arguments (also within response files).
+   + support for 'single'- and "double"-quoted arguments (also within response files);
+   + include paths (`-I`, `-include`, `-isystem` and so on) recognized;
+   + defined (-D) and undefined (-U) preprocessor macros recognized;
+   + language (C, C++) and standard (`c++17`, `gnu++14`) recognized;
+   + `-nostdinc`, `-nostdinc++` and similar switches recognized.
 
 ## Other JSON formats
 

--- a/kompiledb-core/src/main/kotlin/com/saveourtool/kompiledb/core/compiler/ParsedCompilerCommand.kt
+++ b/kompiledb-core/src/main/kotlin/com/saveourtool/kompiledb/core/compiler/ParsedCompilerCommand.kt
@@ -25,6 +25,8 @@ import kotlin.collections.Map.Entry
  * @param language the language of the source file (C, C++, or other).
  * @param languageStandard the language standard, such as `c++23`, `gnu++14`, or
  *   `iso9899:2018`.
+ * @param standardIncludePaths the standard include paths (those which don't
+ *   need to be explicitly requested via `-I`).
  * @param includePaths the include paths.
  *   The keys are command-line switches such as `-I` or `-include`.
  *   The values are paths to include files or directories.
@@ -47,6 +49,7 @@ data class ParsedCompilerCommand(
     val compiler: EnvPath,
     val language: Language,
     val languageStandard: String?,
+    val standardIncludePaths: Set<StandardIncludePaths>,
     val includePaths: Map<String, List<EnvPath>>,
     val definedMacros: Map<String, String>,
     val undefinedMacros: List<String>,

--- a/kompiledb-core/src/main/kotlin/com/saveourtool/kompiledb/core/compiler/StandardIncludePaths.kt
+++ b/kompiledb-core/src/main/kotlin/com/saveourtool/kompiledb/core/compiler/StandardIncludePaths.kt
@@ -1,0 +1,26 @@
+package com.saveourtool.kompiledb.core.compiler
+
+/**
+ * Standard include paths (those which don't need to be explicitly requested via
+ * `-I`). These include paths may be both language- and compiler-dependent.
+ */
+enum class StandardIncludePaths {
+    /**
+     * The headers of the standard C library, such as `stdio.h`, usually located
+     * under `/usr/include`.
+     */
+    STANDARD_C_LIBRARY,
+
+    /**
+     * The headers of the standard C++ library, such as `iostream`, usually
+     * located under `/usr/include/c++`.
+     */
+    STANDARD_CXX_LIBRARY,
+
+    /**
+     * Compiler-specific builtin directories for include files, such as
+     * `/usr/lib/llvm-11/lib/clang/11.0.1/include` or
+     * `/usr/lib/gcc/x86_64-linux-gnu/10/include`.
+     */
+    COMPILER_BUILTIN_INCLUDES,
+}

--- a/kompiledb-core/src/main/kotlin/com/saveourtool/kompiledb/core/compiler/clang/ClangCommandParser.kt
+++ b/kompiledb-core/src/main/kotlin/com/saveourtool/kompiledb/core/compiler/clang/ClangCommandParser.kt
@@ -162,6 +162,13 @@ internal class ClangCommandParser(
         if ("-nostdinc++" in excludedStandardHeaders) {
             standardIncludePaths -= STANDARD_CXX_LIBRARY
         }
+        if ("-nostdlibinc" in excludedStandardHeaders) {
+            standardIncludePaths -= STANDARD_C_LIBRARY
+            standardIncludePaths -= STANDARD_CXX_LIBRARY
+        }
+        if ("-nobuiltininc" in excludedStandardHeaders) {
+            standardIncludePaths -= COMPILER_BUILTIN_INCLUDES
+        }
 
         return ParsedCompilerCommand(
             projectRoot = projectRoot,

--- a/kompiledb-core/src/main/kotlin/com/saveourtool/kompiledb/core/compiler/clang/ClangCommandParser.kt
+++ b/kompiledb-core/src/main/kotlin/com/saveourtool/kompiledb/core/compiler/clang/ClangCommandParser.kt
@@ -232,6 +232,22 @@ internal class ClangCommandParser(
             "cxx",
         )
 
+        /**
+         * - `-nostdinc`: **exclude** all the headers (GCC),
+         *     or **retain** only the standard C++ headers for C++ (Clang)
+         * - `-nostdinc++`: **exclude** the standard C++ headers.
+         * - `-nostdlibinc`: **retain** only the compiler built-in headers (Clang).
+         * - `-nobuiltininc`: **exclude** the compiler built-in headers (Clang),
+         *     but **retain** either the standard C, or both C and C++ headers,
+         *     depending on the language.
+         */
+        private val NOSTDINC: Array<out String> = arrayOf(
+            "-nostdinc",
+            "-nostdinc++",
+            "-nostdlibinc",
+            "-nobuiltininc",
+        )
+
         private val Arg.isResponseFile: Boolean
             get() =
                 isNotEmpty() && this[0] == RESPONSE_FILE

--- a/kompiledb-core/src/main/kotlin/com/saveourtool/kompiledb/core/compiler/clang/ClangCommandParser.kt
+++ b/kompiledb-core/src/main/kotlin/com/saveourtool/kompiledb/core/compiler/clang/ClangCommandParser.kt
@@ -4,6 +4,7 @@ import com.saveourtool.kompiledb.core.CompilationCommand
 import com.saveourtool.kompiledb.core.EnvPath
 import com.saveourtool.kompiledb.core.compiler.CompilerCommandParser
 import com.saveourtool.kompiledb.core.compiler.ParsedCompilerCommand
+import com.saveourtool.kompiledb.core.compiler.StandardIncludePaths
 import com.saveourtool.kompiledb.core.io.Arg
 import com.saveourtool.kompiledb.core.io.CommandLineParser
 import com.saveourtool.kompiledb.core.io.PathMapper
@@ -15,6 +16,7 @@ import com.saveourtool.kompiledb.core.lang.Language
 import com.saveourtool.kompiledb.core.lang.Language.Companion.UNKNOWN
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
+import java.util.EnumSet
 import kotlin.Result.Companion.failure
 import kotlin.io.path.extension
 import kotlin.io.path.isDirectory
@@ -138,6 +140,7 @@ internal class ClangCommandParser(
             compiler = compiler,
             language = language ?: command.file.language,
             languageStandard = languageStandard,
+            standardIncludePaths = EnumSet.allOf(StandardIncludePaths::class.java),
             includePaths = includePaths,
             definedMacros = definedMacros,
             undefinedMacros = undefinedMacros,

--- a/kompiledb-core/src/main/kotlin/com/saveourtool/kompiledb/core/compiler/clang/ClangCommandParser.kt
+++ b/kompiledb-core/src/main/kotlin/com/saveourtool/kompiledb/core/compiler/clang/ClangCommandParser.kt
@@ -159,6 +159,9 @@ internal class ClangCommandParser(
                 else -> standardIncludePaths -= STANDARD_CXX_LIBRARY
             }
         }
+        if ("-nostdinc++" in excludedStandardHeaders) {
+            standardIncludePaths -= STANDARD_CXX_LIBRARY
+        }
 
         return ParsedCompilerCommand(
             projectRoot = projectRoot,

--- a/kompiledb-core/src/main/kotlin/com/saveourtool/kompiledb/core/io/PathMapperScope.kt
+++ b/kompiledb-core/src/main/kotlin/com/saveourtool/kompiledb/core/io/PathMapperScope.kt
@@ -5,6 +5,7 @@ import org.jetbrains.annotations.Contract
 import java.nio.file.Path
 import kotlin.Result.Companion.success
 import kotlin.io.path.div
+import kotlin.io.path.name
 
 /**
  * A set of extensions to [EnvPath] which are not dependent on the
@@ -15,6 +16,19 @@ interface PathMapperScope {
      * The path mapper which performs path translation.
      */
     val pathMapper: PathMapper
+
+    /**
+     * @return the name of the file or directory denoted by this path as a
+     *   string, or an empty string if this path has zero path elements, or path
+     *   mapping fails.
+     * @see Path.name
+     * @see Path.getFileName
+     */
+    val EnvPath.name: String
+        get() =
+            with(pathMapper) {
+                toLocalPath().map(Path::name).getOrNull().orEmpty()
+            }
 
     /**
      * Resolve the given [other] path against this path.

--- a/kompiledb-core/src/test/kotlin/com/saveourtool/kompiledb/core/compiler/CompilerCommandParserTest.kt
+++ b/kompiledb-core/src/test/kotlin/com/saveourtool/kompiledb/core/compiler/CompilerCommandParserTest.kt
@@ -788,6 +788,35 @@ class CompilerCommandParserTest {
         )
     }
 
+    @Test
+    fun `nostdinc and nostdinc++ combined`() {
+        @Language("sh")
+        val commands = sequenceOf(
+            "clang -xc -nostdinc -nostdinc++ -c file",
+            "clang -xc++ -nostdinc -nostdinc++ -c file",
+            "gcc -xc -nostdinc -nostdinc++ -c file",
+            "gcc -xc++ -nostdinc -nostdinc++ -c file",
+        )
+
+        assertAll(
+            commands
+                .map { command ->
+                    CompilationCommand(
+                        directory = EMPTY,
+                        file = EnvPath("file"),
+                        command = command,
+                    )
+                }
+                .map { command ->
+                    CompilerCommandParser().parse(Path(""), command)
+                }
+                .map { command ->
+                    { command.standardIncludePaths.shouldBeEmpty() }.lazyUnit
+                }
+                .toList()
+        )
+    }
+
     private companion object {
         private val <T> (() -> T).lazyUnit: () -> Unit
             get() = {

--- a/kompiledb-core/src/test/kotlin/com/saveourtool/kompiledb/core/compiler/CompilerCommandParserTest.kt
+++ b/kompiledb-core/src/test/kotlin/com/saveourtool/kompiledb/core/compiler/CompilerCommandParserTest.kt
@@ -760,6 +760,34 @@ class CompilerCommandParserTest {
         CompilerCommandParser().parse(Path(""), command).standardIncludePaths.shouldBeEmpty()
     }
 
+    @Test
+    fun `nostdinc++ (C)`() {
+        val command = CompilationCommand(
+            directory = EMPTY,
+            file = EnvPath("file.cc"),
+            command = "clang -xc -nostdinc++ -c file",
+        )
+
+        CompilerCommandParser().parse(Path(""), command).standardIncludePaths.shouldContainExactlyInAnyOrder(
+            STANDARD_C_LIBRARY,
+            COMPILER_BUILTIN_INCLUDES,
+        )
+    }
+
+    @Test
+    fun `nostdinc++ (C++)`() {
+        val command = CompilationCommand(
+            directory = EMPTY,
+            file = EnvPath("file.cc"),
+            command = "clang -xc++ -nostdinc++ -c file",
+        )
+
+        CompilerCommandParser().parse(Path(""), command).standardIncludePaths.shouldContainExactlyInAnyOrder(
+            STANDARD_C_LIBRARY,
+            COMPILER_BUILTIN_INCLUDES,
+        )
+    }
+
     private companion object {
         private val <T> (() -> T).lazyUnit: () -> Unit
             get() = {

--- a/kompiledb-core/src/test/kotlin/com/saveourtool/kompiledb/core/compiler/CompilerCommandParserTest.kt
+++ b/kompiledb-core/src/test/kotlin/com/saveourtool/kompiledb/core/compiler/CompilerCommandParserTest.kt
@@ -3,6 +3,9 @@ package com.saveourtool.kompiledb.core.compiler
 import com.saveourtool.kompiledb.core.CompilationCommand
 import com.saveourtool.kompiledb.core.EnvPath
 import com.saveourtool.kompiledb.core.EnvPath.Companion.EMPTY
+import com.saveourtool.kompiledb.core.compiler.StandardIncludePaths.COMPILER_BUILTIN_INCLUDES
+import com.saveourtool.kompiledb.core.compiler.StandardIncludePaths.STANDARD_CXX_LIBRARY
+import com.saveourtool.kompiledb.core.compiler.StandardIncludePaths.STANDARD_C_LIBRARY
 import com.saveourtool.kompiledb.core.lang.C
 import com.saveourtool.kompiledb.core.lang.Cxx
 import io.kotest.matchers.collections.shouldBeEmpty
@@ -681,6 +684,35 @@ class CompilerCommandParserTest {
         )
 
         CompilerCommandParser().parse(Path(""), command).languageStandard.shouldNotBeNull() shouldBeEqual "c++14"
+    }
+
+    @Test
+    fun `default standard include paths (C)`() {
+        val command = CompilationCommand(
+            directory = EMPTY,
+            file = EnvPath("file.cc"),
+            command = "clang -xc -c file",
+        )
+
+        CompilerCommandParser().parse(Path(""), command).standardIncludePaths.shouldContainExactlyInAnyOrder(
+            STANDARD_C_LIBRARY,
+            COMPILER_BUILTIN_INCLUDES,
+        )
+    }
+
+    @Test
+    fun `default standard include paths (C++)`() {
+        val command = CompilationCommand(
+            directory = EMPTY,
+            file = EnvPath("file.cc"),
+            command = "clang -xc++ -c file",
+        )
+
+        CompilerCommandParser().parse(Path(""), command).standardIncludePaths.shouldContainExactlyInAnyOrder(
+            STANDARD_C_LIBRARY,
+            STANDARD_CXX_LIBRARY,
+            COMPILER_BUILTIN_INCLUDES,
+        )
     }
 
     private companion object {

--- a/kompiledb-core/src/test/kotlin/com/saveourtool/kompiledb/core/compiler/CompilerCommandParserTest.kt
+++ b/kompiledb-core/src/test/kotlin/com/saveourtool/kompiledb/core/compiler/CompilerCommandParserTest.kt
@@ -794,8 +794,12 @@ class CompilerCommandParserTest {
         val commands = sequenceOf(
             "clang -xc -nostdinc -nostdinc++ -c file",
             "clang -xc++ -nostdinc -nostdinc++ -c file",
+            "clang -nostdinc -nostdinc++ -c file.c",
+            "clang -nostdinc -nostdinc++ -c file.cc",
             "gcc -xc -nostdinc -nostdinc++ -c file",
             "gcc -xc++ -nostdinc -nostdinc++ -c file",
+            "gcc -nostdinc -nostdinc++ -c file.c",
+            "gcc -nostdinc -nostdinc++ -c file.cc",
         )
 
         assertAll(
@@ -823,6 +827,8 @@ class CompilerCommandParserTest {
         val commands = sequenceOf(
             "clang -xc -nostdlibinc -c file",
             "clang -xc++ -nostdlibinc -c file",
+            "clang -nostdlibinc -c file.c",
+            "clang -nostdlibinc -c file.cc",
         )
 
         assertAll(
@@ -875,6 +881,8 @@ class CompilerCommandParserTest {
         val commands = sequenceOf(
             "clang -xc -nostdlibinc -nobuiltininc -c file",
             "clang -xc++ -nostdlibinc -nobuiltininc -c file",
+            "clang -nostdlibinc -nobuiltininc -c file.c",
+            "clang -nostdlibinc -nobuiltininc -c file.cc",
         )
 
         assertAll(

--- a/kompiledb-core/src/test/kotlin/com/saveourtool/kompiledb/core/compiler/CompilerCommandParserTest.kt
+++ b/kompiledb-core/src/test/kotlin/com/saveourtool/kompiledb/core/compiler/CompilerCommandParserTest.kt
@@ -11,6 +11,7 @@ import com.saveourtool.kompiledb.core.lang.Cxx
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldContainOnly
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.maps.shouldContainExactly
@@ -713,6 +714,50 @@ class CompilerCommandParserTest {
             STANDARD_CXX_LIBRARY,
             COMPILER_BUILTIN_INCLUDES,
         )
+    }
+
+    @Test
+    fun `nostdinc (Clang, C)`() {
+        val command = CompilationCommand(
+            directory = EMPTY,
+            file = EnvPath("file.cc"),
+            command = "clang -xc -nostdinc -c file",
+        )
+
+        CompilerCommandParser().parse(Path(""), command).standardIncludePaths.shouldBeEmpty()
+    }
+
+    @Test
+    fun `nostdinc (GCC, C)`() {
+        val command = CompilationCommand(
+            directory = EMPTY,
+            file = EnvPath("file.cc"),
+            command = "gcc -xc -nostdinc -c file",
+        )
+
+        CompilerCommandParser().parse(Path(""), command).standardIncludePaths.shouldBeEmpty()
+    }
+
+    @Test
+    fun `nostdinc (Clang, C++)`() {
+        val command = CompilationCommand(
+            directory = EMPTY,
+            file = EnvPath("file.cc"),
+            command = "clang -xc++ -nostdinc -c file",
+        )
+
+        CompilerCommandParser().parse(Path(""), command).standardIncludePaths.shouldContainOnly(STANDARD_CXX_LIBRARY)
+    }
+
+    @Test
+    fun `nostdinc (GCC, C++)`() {
+        val command = CompilationCommand(
+            directory = EMPTY,
+            file = EnvPath("file.cc"),
+            command = "gcc -xc++ -nostdinc -c file",
+        )
+
+        CompilerCommandParser().parse(Path(""), command).standardIncludePaths.shouldBeEmpty()
     }
 
     private companion object {


### PR DESCRIPTION
 - Fixes #25.